### PR TITLE
Add LangChain RAG Streamlit app

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+HUGGINGFACEHUB_API_TOKEN=your_token

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# rag-learning
+# RAG PDF QA App
+
+This project demonstrates a simple Retrieval-Augmented Generation (RAG) pipeline using LangChain and a remote Hugging Face LLM. The app runs locally via Streamlit and lets you query information from your own PDF files.
+
+## Setup
+
+1. **Clone the repository** and create a Python virtual environment (optional but recommended).
+2. **Install dependencies**:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. **Get a Hugging Face API token**:
+   - Create a free account at [huggingface.co](https://huggingface.co/).
+   - Generate a token with access to the Inference API.
+4. **Configure the token**:
+   - Copy `.env` and add your token:
+     ```bash
+     cp .env .env.local
+     echo "HUGGINGFACEHUB_API_TOKEN=your_actual_token" > .env.local
+     ```
+   - The application loads this variable at runtime.
+
+## Running the App
+
+1. Place the PDF files you want to query in a folder on your machine.
+2. Start the Streamlit app:
+   ```bash
+   streamlit run app.py
+   ```
+3. Enter the path to your PDF folder in the web interface, then ask questions about the content.
+
+The application uses the `mistralai/Mistral-7B-Instruct-v0.1` model via the Hugging Face Inference API and embeds your PDF text locally using `sentence-transformers/all-MiniLM-L6-v2` with FAISS for retrieval.
+
+## Notes
+
+- The app works fully offline except for calls to the Hugging Face Inference API.
+- Errors such as missing PDFs or API issues are reported in the Streamlit interface.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,26 @@
+import streamlit as st
+from rag_chain import RAGPipeline
+
+st.title("RAG PDF QA")
+
+# Input for folder containing PDFs
+pdf_folder = st.text_input("Path to folder with PDFs")
+
+if pdf_folder:
+    if 'rag' not in st.session_state:
+        try:
+            rag = RAGPipeline(pdf_folder)
+            rag.ingest_pdfs()
+            rag.build_qa_chain()
+            st.session_state['rag'] = rag
+            st.success("PDFs loaded and embeddings created")
+        except Exception as e:
+            st.error(f"Error initializing RAG pipeline: {e}")
+
+    question = st.text_input("Ask a question about your PDFs")
+    if question and 'rag' in st.session_state:
+        try:
+            answer = st.session_state['rag'].query(question)
+            st.write(answer)
+        except Exception as e:
+            st.error(f"Error running query: {e}")

--- a/llm_config.py
+++ b/llm_config.py
@@ -1,0 +1,20 @@
+import os
+from langchain.llms import HuggingFaceHub
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+def get_llm(model_name: str = "mistralai/Mistral-7B-Instruct-v0.1") -> HuggingFaceHub:
+    """Configure and return the remote Hugging Face LLM."""
+    api_token = os.getenv("HUGGINGFACEHUB_API_TOKEN")
+    if not api_token:
+        raise ValueError("HUGGINGFACEHUB_API_TOKEN not set in environment")
+
+    # Setup HuggingFaceHub LLM
+    llm = HuggingFaceHub(
+        repo_id=model_name,
+        huggingfacehub_api_token=api_token,
+        model_kwargs={"temperature": 0.0, "max_new_tokens": 512},
+    )
+    return llm

--- a/rag_chain.py
+++ b/rag_chain.py
@@ -1,0 +1,44 @@
+import os
+from typing import Optional
+from langchain.vectorstores import FAISS
+from langchain.embeddings import HuggingFaceEmbeddings
+from langchain.chains import RetrievalQA
+from langchain.schema import BaseRetriever
+
+from utils import load_pdfs_from_folder, split_documents
+from llm_config import get_llm
+
+
+class RAGPipeline:
+    """Class to build and run a simple RAG pipeline."""
+
+    def __init__(self, pdf_folder: str, embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2"):
+        self.pdf_folder = pdf_folder
+        self.embedding_model = embedding_model
+        self.vector_store: Optional[FAISS] = None
+        self.retriever: Optional[BaseRetriever] = None
+        self.qa_chain: Optional[RetrievalQA] = None
+
+    def ingest_pdfs(self) -> None:
+        """Load, split, embed PDFs and create FAISS vector store."""
+        documents = load_pdfs_from_folder(self.pdf_folder)
+        splits = split_documents(documents)
+
+        embeddings = HuggingFaceEmbeddings(model_name=self.embedding_model)
+        self.vector_store = FAISS.from_documents(splits, embeddings)
+        self.retriever = self.vector_store.as_retriever()
+
+    def build_qa_chain(self) -> None:
+        """Set up the RetrievalQA chain with the remote LLM."""
+        if self.retriever is None:
+            raise ValueError("Vector store not initialized. Run ingest_pdfs() first.")
+
+        llm = get_llm()
+        self.qa_chain = RetrievalQA.from_chain_type(llm, retriever=self.retriever)
+
+    def query(self, question: str) -> str:
+        """Ask a question using the RAG pipeline."""
+        if self.qa_chain is None:
+            raise ValueError("QA chain not created. Run build_qa_chain() first.")
+        result = self.qa_chain.run(question)
+        return result

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+langchain
+faiss-cpu
+streamlit
+python-dotenv
+huggingface-hub
+pypdf

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,23 @@
+import os
+from typing import List
+from langchain.document_loaders import PyPDFLoader, DirectoryLoader
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.schema import Document
+
+
+def load_pdfs_from_folder(folder_path: str) -> List[Document]:
+    """Load all PDFs from a folder using LangChain's DirectoryLoader."""
+    if not os.path.exists(folder_path):
+        raise FileNotFoundError(f"Folder not found: {folder_path}")
+
+    loader = DirectoryLoader(folder_path, glob="*.pdf", loader_cls=PyPDFLoader)
+    documents = loader.load()
+    if not documents:
+        raise FileNotFoundError(f"No PDF files found in {folder_path}")
+    return documents
+
+
+def split_documents(documents: List[Document], chunk_size: int = 1000, chunk_overlap: int = 200) -> List[Document]:
+    """Split documents into smaller chunks for embedding."""
+    splitter = RecursiveCharacterTextSplitter(chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+    return splitter.split_documents(documents)


### PR DESCRIPTION
## Summary
- implement modular RAG pipeline with LangChain
- remote LLM config via Hugging Face Hub
- utilities to load and split PDFs
- FAISS-based retrieval chain
- Streamlit web UI
- usage instructions and dependencies

## Testing
- `python -m py_compile llm_config.py utils.py rag_chain.py app.py`


------
https://chatgpt.com/codex/tasks/task_b_68657e60b0b8832c8087e9182f46890b